### PR TITLE
Fix loading profile name instead of project name

### DIFF
--- a/src/main/kotlin/com/github/rinchinov/ijdbtplugin/services/ProjectConfigurations.kt
+++ b/src/main/kotlin/com/github/rinchinov/ijdbtplugin/services/ProjectConfigurations.kt
@@ -54,7 +54,7 @@ class ProjectConfigurations(private val project: Project) {
         val profileFile = Paths.get(getDbtProfileDirAbsolute().toString(), "profiles.yml")
         val inputStream: InputStream = Files.newInputStream(profileFile)
         val profilesRaw = Yaml().load(inputStream) as Map<String, Map<String, Map<String, Map<String, Any>>>>?
-        val raw = profilesRaw?.get(dbtProjectConfig.name)
+        val raw = profilesRaw?.get(dbtProjectConfig.profile)
         dbtProjectConfig.projectProfiles = raw?.get("outputs") as Map<String, Map<String, Any>>
         dbtProjectConfig.defaultTarget = raw["target"] as String
         dbtProjectConfig.targets = dbtProjectConfig.projectProfiles?.keys?.toList() ?: emptyList()


### PR DESCRIPTION
If your project name is `foo` and your `profile` name is something else (`bar`), and you don't have it in `profiles.yml`, the plugin fails to launch.

```yaml
name: "foo"
profile: "bar"
```