### PR TITLE
Add substitutor for SQL files to automatically syntax highlight SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,6 @@ Ensure you have a Python SDK configured in IDE with DBT installed. This setup is
 
 - Open any DBT project in PyCharm to automatically unlock advanced navigation features, making every DBT component effortlessly accessible.
 
-### Configure Jinja2 for `.sql` and `.yml` Files
-
-1. **Access Settings**: Go to `File` > `Settings` > `Languages & Frameworks` > `Template Languages`.
-2. **Select Template Language**: Choose `Jinja2` and include `sql` and `yml` in `Template File Types`.
-
 ### Optional: Restart PyCharm/IntelliJ IDEA
 
 - A restart may be necessary to fully integrate the new settings, optimizing your plugin experience.

--- a/src/main/kotlin/com/github/rinchinov/ijdbtplugin/DbtJinjaLanguageSubstitutor.kt
+++ b/src/main/kotlin/com/github/rinchinov/ijdbtplugin/DbtJinjaLanguageSubstitutor.kt
@@ -8,10 +8,9 @@ import com.intellij.psi.LanguageSubstitutor
 
 class DbtJinjaLanguageSubstitutor : LanguageSubstitutor() {
     override fun getLanguage(file: VirtualFile, project: Project): Language? {
-        if (file.extension == "sql") {
-            return Jinja2Language.INSTANCE
+        return when (file.extension){
+            "sql", "yml" -> Jinja2Language.INSTANCE
+            else -> null
         }
-
-        return null;
     }
 }

--- a/src/main/kotlin/com/github/rinchinov/ijdbtplugin/DbtJinjaLanguageSubstitutor.kt
+++ b/src/main/kotlin/com/github/rinchinov/ijdbtplugin/DbtJinjaLanguageSubstitutor.kt
@@ -1,0 +1,17 @@
+package com.github.rinchinov.ijdbtplugin
+
+import com.intellij.jinja.Jinja2Language
+import com.intellij.lang.Language
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.LanguageSubstitutor
+
+class DbtJinjaLanguageSubstitutor : LanguageSubstitutor() {
+    override fun getLanguage(file: VirtualFile, project: Project): Language? {
+        if (file.extension == "sql") {
+            return Jinja2Language.INSTANCE
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,6 +29,8 @@
                 anchor="bottom"
                 id="DBT"/>
 
+        <lang.substitutor language="SQL" implementationClass="com.github.rinchinov.ijdbtplugin.DbtJinjaLanguageSubstitutor" order="first"/>
+
         <psi.referenceContributor
                 implementation="com.github.rinchinov.ijdbtplugin.ref.DbtPsiReferenceContributor"
                 language="DjangoTemplate"/>


### PR DESCRIPTION
TIL about [LanguageSubstitutor](https://github.com/JetBrains/intellij-community/blob/idea/241.14494.240/platform/core-api/src/com/intellij/psi/LanguageSubstitutor.java) :-).

This allows syntax highlighting to automatically be applied for SQL files, without needing to automatically add it. One less step. Could also be removed from the README! :tada:

Not sure if we should filter for actual dbt files (models, tests, etc) or if this will be too slow to check, as this function is accessed quite often.

Also thinking if we should add YML to this as well, but filter for the YML files under paths outlined in [dbt_project.yml docs](https://docs.getdbt.com/reference/dbt_project.yml)?